### PR TITLE
Chore remove nemotron model

### DIFF
--- a/ollama_service.py
+++ b/ollama_service.py
@@ -17,7 +17,6 @@ MODEL_IDS: list[str] = [
     "llama3:8b",
     "llama3.2",
     "mistral",
-    "nemotron",
     "gemma2",
     "qwen2.5",
 ]

--- a/ollama_service.py
+++ b/ollama_service.py
@@ -14,7 +14,7 @@ logging.basicConfig(level=logging.INFO)
 
 # Default server port.
 MODEL_IDS: list[str] = [
-    "llama3:8b",
+    "llama3",
     "llama3.2",
     "mistral",
     "gemma2",


### PR DESCRIPTION
I have moved the nemotron model to use the github models instead, as nemotron was an absolutely massive model to try and run on gpu's and would often be quite slow when trying to use it via just our own containers. API is much faster.