### PR TITLE
Add cicd for modal deployment to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: CI/CD
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    env:
+      MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install Poetry
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+
+      - name: Install Dependencies
+        run: |
+          poetry install
+
+      - name: Install Modal
+        run: |
+          python -m pip install --upgrade pip
+          pip install modal
+
+      - name: Deploy job
+        run: |
+          modal deploy --env dev deploy


### PR DESCRIPTION
This pull request introduces a new CI/CD workflow configuration in the `.github/workflows/deploy.yml` file. The workflow is set up to run on pushes to the `main` branch and includes steps for setting up the environment, installing dependencies, and deploying the application.

Key changes:

* Added a new workflow named `CI/CD` that triggers on pushes to the `main` branch.
* Configured the `deploy` job to run on `ubuntu-latest` and set up environment variables using GitHub secrets.
* Added steps to:
  - Checkout the repository using `actions/checkout@v4`.
  - Install Python 3.10 using `actions/setup-python@v5`.
  - Install Poetry and project dependencies.
  - Install Modal and deploy the application using `modal deploy --env dev deploy`.