### PR TITLE
Move breaking import into modal imports

### DIFF
--- a/ai_router.py
+++ b/ai_router.py
@@ -6,7 +6,6 @@ from fastapi import FastAPI, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 from contextlib import contextmanager
-from openai import OpenAIError
 from modal import Image, App, asgi_app, Secret
 
 # Configure logging
@@ -48,6 +47,7 @@ llm_compare_app = App(
 with llm_compare_app.image.imports():
     from litellm import completion
     from supabase import create_client, Client
+    from openai import OpenAIError
 
     # Initialize Supabase client
     supabase_url = os.environ["SUPABASE_URL"]


### PR DESCRIPTION
This pull request includes a small change to the `ai_router.py` file. The change reorders imports to ensure that `OpenAIError` is imported only when necessary.

Import reordering:

* [`ai_router.py`](diffhunk://#diff-7c35c14986a93d10e39f471b5296c405c044dc72e08ca213f6e5511160513e67L9): Removed the import of `OpenAIError` from the global scope and added it within the `llm_compare_app.image.imports()` context. [[1]](diffhunk://#diff-7c35c14986a93d10e39f471b5296c405c044dc72e08ca213f6e5511160513e67L9) [[2]](diffhunk://#diff-7c35c14986a93d10e39f471b5296c405c044dc72e08ca213f6e5511160513e67R50)