### PR TITLE
update models to only download compatible ones

### DIFF
--- a/ollama_service.py
+++ b/ollama_service.py
@@ -19,10 +19,7 @@ MODEL_IDS: list[str] = [
     "mistral",
     "gemma2",
     "qwen2.5",
-    "hf.co/aisingapore/gemma2-9b-cpt-sea-lionv3-instruct",
-    "hf.co/mesolitica/malaysian-Llama-3.2-3B-Instruct",
-    "hf.co/tencent/Tencent-Hunyuan-Large",
-    "hf.co/aisingapore/gemma2-9b-cpt-sea-lionv3-base",
+    "aisingapore/gemma2-9b-cpt-sea-lionv3-instruct",
 ]
 
 OLLAMA_PORT: int = 11434


### PR DESCRIPTION
This pull request includes a change to the `ollama_service.py` file, which updates the list of models by removing some models and modifying the URL format for an existing model.

Model list update:

* Removed the following models from the list: `hf.co/aisingapore/gemma2-9b-cpt-sea-lionv3-instruct`, `hf.co/mesolitica/malaysian-Llama-3.2-3B-Instruct`, `hf.co/tencent/Tencent-Hunyuan-Large`, and `hf.co/aisingapore/gemma2-9b-cpt-sea-lionv3-base`.
* Modified the URL format for the `aisingapore/gemma2-9b-cpt-sea-lionv3-instruct` model by removing the `hf.co/` prefix.