### PR TITLE
remove it as it was not showcasing anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ modal serve --env dev deploy
 ```
 
 
-<iframe src="https://supa-dev--llm-comparison-api-fastapi-app.modal.run/docs" width="100%" height="800px" frameborder="0" style="border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);" title="LLM Comparison API Documentation"> </iframe> 
+
 
 
 <h2 id="converter">🔄 GGUF Converter</h2> <h3>Setup</h3>


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file. The change removes an embedded iframe that linked to the LLM Comparison API documentation.

Documentation Update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L73-R73): Removed the iframe that linked to the LLM Comparison API documentation.