### PR TITLE
Fix link to Pull Request tutorial in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,6 @@ Here you will explain how other developers can contribute to your project. For e
  
 <h3>Documentations that might help</h3>
 
-[📝 How to create a Pull Request](https://www.atlassian.com/br/git/tutorials/making-a-pull-request)
+[📝 How to create a Pull Request](https://www.atlassian.com/en/git/tutorials/making-a-pull-request)
 
 [💾 Commit pattern](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)


### PR DESCRIPTION
This pull request includes a small update to the `README.md` file. The change corrects a link to the tutorial on how to create a pull request.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L156-R156): Fixed the link to the "How to create a Pull Request" tutorial by changing the URL from the Brazilian version to the English version.