### PR TITLE
Add new indo models to ollama 

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,6 @@ Here you will explain how other developers can contribute to your project. For e
  
 <h3>Documentations that might help</h3>
 
-[📝 How to create a Pull Request](https://www.atlassian.com/br/git/tutorials/making-a-pull-request)
+[📝 How to create a Pull Request](https://www.atlassian.com/en/git/tutorials/making-a-pull-request)
 
 [💾 Commit pattern](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)

--- a/ollama_service.py
+++ b/ollama_service.py
@@ -20,7 +20,9 @@ MODEL_IDS: list[str] = [
     "gemma2",
     "qwen2.5",
     "aisingapore/gemma2-9b-cpt-sea-lionv3-instruct",
-    "hf.co/Supa-AI/malaysian-Llama-3.2-3B-Instruct-Q8_0-GGUF"
+    "hf.co/Supa-AI/malaysian-Llama-3.2-3B-Instruct-Q8_0-GGUF",
+    "hf.co/Supa-AI/gemma2-9b-cpt-sahabatai-v1-instruct-q8_0-gguf",
+    "hf.co/Supa-AI/llama3-8b-cpt-sahabatai-v1-instruct-q8_0-gguf"
 ]
 
 OLLAMA_PORT: int = 11434


### PR DESCRIPTION
This pull request includes an update to the `ollama_service.py` file to add new models to the list of supported models.

Model updates:

* Added `"hf.co/Supa-AI/gemma2-9b-cpt-sahabatai-v1-instruct-q8_0-gguf"` to the list of models.
* Added `"hf.co/Supa-AI/llama3-8b-cpt-sahabatai-v1-instruct-q8_0-gguf"` to the list of models.