### PR TITLE
Ensure model name is always lowercase + add clean-run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ modal run --detach hugging_face_to_guff.py \
   --quanttype q8_0 \
   --username Supa-AI \
   --ollama-upload \
-  --hf-upload
+  --hf-upload \
+  --clean-run
 ```
 - The `--detach` command is used to allow this program to run even if your terminal disconnects from the modal servers
 - `modelowner` is the repo owner that you are trying to get the model from
@@ -98,6 +99,7 @@ modal run --detach hugging_face_to_guff.py \
 - `ollama-upload` is a boolean determiner for whether it should also upload the newly created quantized models to ollama under your username.
     - **Important note!** Before uploading, make sure that the volume called `ollama` is created, once created you must run `ollama serve` on your own machine to retrieve the public and private sh keys to add to ollama, more details can be found [here](https://github.com/ollama/ollama/blob/main/docs/import.md)
 - `hf-upload` another boolean determiner on whether it should upload these models to your hugging face repo 
+- `clean-run` is a boolean determiner on whether it should clean up all the existing model files in your ollama volume before running, this can fix issues where ollama won't let you re-run due to the model already existing in your volume from a previous run.
 
 <h3>Technical Details</h3>
 


### PR DESCRIPTION
After attempting to convert the new mistral ai models from hugging face to guff,  I found that ollama was giving me the `blob not found` error. It turns out that ollama only allows for lowercase model names to be uploaded, and might flat-out refuse to save/retrieve model names with capitalized letters. 

This is the ollama issue that helped lead me to this conclusion: https://github.com/ollama/ollama/issues/3297

===

This pull request introduces a new `clean_run` parameter to the `hugging_face_to_guff.py` script, enhancing its functionality by enabling the removal of existing models in the Ollama directory before uploading new ones. Additionally, it includes improvements to error handling and logging for better debugging and traceability.

Enhancements to functionality:

* [`hugging_face_to_guff.py`](diffhunk://#diff-fe5524f03944fb8f333a7c359df9229d4893b3263b98bda3e9e186299b90da02L87-R88): Added a new `clean_run` parameter to the `download_model`, `convert_to_gguf`, `push_to_ollama`, and `main` functions, allowing users to request a clean run that removes existing Ollama models before uploading new ones. [[1]](diffhunk://#diff-fe5524f03944fb8f333a7c359df9229d4893b3263b98bda3e9e186299b90da02L87-R88) [[2]](diffhunk://#diff-fe5524f03944fb8f333a7c359df9229d4893b3263b98bda3e9e186299b90da02R163) [[3]](diffhunk://#diff-fe5524f03944fb8f333a7c359df9229d4893b3263b98bda3e9e186299b90da02R249-R281) [[4]](diffhunk://#diff-fe5524f03944fb8f333a7c359df9229d4893b3263b98bda3e9e186299b90da02L302-R378)

Improvements to error handling and logging:

* [`hugging_face_to_guff.py`](diffhunk://#diff-fe5524f03944fb8f333a7c359df9229d4893b3263b98bda3e9e186299b90da02L269-R362): Enhanced the `push_to_ollama` function with additional logging for model path verification, absolute path usage, and detailed error messages. Improved the process of waiting for the Ollama service by adding retries and logging the status.
* [`hugging_face_to_guff.py`](diffhunk://#diff-fe5524f03944fb8f333a7c359df9229d4893b3263b98bda3e9e186299b90da02L269-R362): Added cleanup of temporary Modelfile after the push process to ensure no leftover files remain.

These changes collectively improve the robustness and usability of the script.