### PR TITLE
Chore add supa ollama models

### DIFF
--- a/hugging_face_to_guff.py
+++ b/hugging_face_to_guff.py
@@ -85,7 +85,7 @@ class ModelConverter:
         private: bool = False,
         ollama_upload: bool = False,
         hf_upload: bool = False,
-        clean_run: bool = False,  # New parameter
+        clean_run: bool = False,  
     ):
         logger.info(f"Downloading model {model_id}...")
         import subprocess
@@ -159,8 +159,8 @@ class ModelConverter:
         branch: str = "",
         filter_path: str = "",
         ollama_upload: bool = False,
-        hf_upload: bool = False,  # New parameter
-        clean_run: bool = False,  # New parameter
+        hf_upload: bool = False,  
+        clean_run: bool = False,  
     ):
         """Convert model to GGUF format with multiple quantization types and push to Ollama"""
         logger.info(f"Converting model with quantization types: {quanttypes}")
@@ -246,7 +246,7 @@ class ModelConverter:
         modelname: str,
         source_model_id: str,
         username: str,
-        clean_run: bool = False,  # New parameter
+        clean_run: bool = False,  
     ):
         """Push converted models to Ollama using tags for different quantizations"""
         logger.info("Pushing models to Ollama...")
@@ -375,7 +375,7 @@ def main(
     private: bool = False,
     ollama_upload: bool = False,
     hf_upload: bool = False,
-    clean_run: bool = False,  # New parameter
+    clean_run: bool = False,  
 ):
     logger.info(f"Starting conversion process for {modelowner}/{modelname}")
     converter = ModelConverter()

--- a/ollama_service.py
+++ b/ollama_service.py
@@ -15,14 +15,18 @@ logging.basicConfig(level=logging.INFO)
 # Default server port.
 MODEL_IDS: list[str] = [
     "llama3",
+    "llama3.1",
     "llama3.2",
     "mistral",
     "gemma2",
     "qwen2.5",
+    "yi",
     "aisingapore/gemma2-9b-cpt-sea-lionv3-instruct",
     "hf.co/Supa-AI/malaysian-Llama-3.2-3B-Instruct-Q8_0-GGUF",
-    "hf.co/Supa-AI/gemma2-9b-cpt-sahabatai-v1-instruct-q8_0-gguf",
-    "hf.co/Supa-AI/llama3-8b-cpt-sahabatai-v1-instruct-q8_0-gguf"
+    "Supa-AI/gemma2-9b-cpt-sahabatai-v1-instruct:q8_0",
+    "Supa-AI/llama3-8b-cpt-sahabatai-v1-instruct:q8_0",
+    "Supa-AI/gemma2-9b-cpt-sahabatai-v1-base:q8_0",
+    "Supa-AI/ministral-8b-instruct-2410:q8_0"
 ]
 
 OLLAMA_PORT: int = 11434


### PR DESCRIPTION
This pull request includes several changes to the `hugging_face_to_guff.py` and `ollama_service.py` files. The primary focus is on cleaning up parameter comments and updating model IDs.

Parameter cleanup in `hugging_face_to_guff.py`:

* Removed unnecessary comments indicating new parameters from the `download_model`, `convert_to_gguf`, `push_to_ollama`, and `main` functions. [[1]](diffhunk://#diff-fe5524f03944fb8f333a7c359df9229d4893b3263b98bda3e9e186299b90da02L88-R88) [[2]](diffhunk://#diff-fe5524f03944fb8f333a7c359df9229d4893b3263b98bda3e9e186299b90da02L162-R163) [[3]](diffhunk://#diff-fe5524f03944fb8f333a7c359df9229d4893b3263b98bda3e9e186299b90da02L249-R249) [[4]](diffhunk://#diff-fe5524f03944fb8f333a7c359df9229d4893b3263b98bda3e9e186299b90da02L378-R378)

Model ID updates in `ollama_service.py`:

* Added new model IDs `llama3.1`, `yi`, and several `Supa-AI` models to the `MODEL_IDS` list.
* Updated the format of existing `Supa-AI` model IDs for consistency.