### PR TITLE
Add upload_to_hf method for uploading GGUF models to HuggingFace

### DIFF
--- a/hugging_face_to_guff.py
+++ b/hugging_face_to_guff.py
@@ -238,6 +238,96 @@ class ModelConverter:
         except Exception as e:
             logger.error(f"Error in conversion/quantization: {str(e)}")
             raise
+    
+    @method()
+    def upload_to_hf(self, model_files: List[tuple], repo_id: str, source_model_id: str, private: bool = False):
+        logger.info("Reloading volume before upload...")
+        volume.reload()
+        
+        logger.info(f"Uploading GGUF models to HuggingFace repo {repo_id}...")
+        from huggingface_hub import HfApi, ModelCard
+        from textwrap import dedent
+        
+        try:
+            api = HfApi()
+            api.create_repo(repo_id, exist_ok=True, private=private, repo_type="model")
+            
+            try:
+                card = ModelCard.load(source_model_id)
+            except Exception:
+                card = ModelCard("")
+                
+            if card.data.tags is None:
+                card.data.tags = []
+            card.data.tags.extend(["llama-cpp", "gguf"])
+            card.data.base_model = source_model_id
+            
+            # Generate model card with all versions
+            versions_text = "\n".join([
+                f"- `{os.path.basename(file)}` ({quant_type})" 
+                for file, quant_type in model_files
+            ])
+            
+            card.text = dedent(f"""
+                # {repo_id}
+                This model was converted to GGUF format from [`{source_model_id}`](https://huggingface.co/{source_model_id}) using llama.cpp.
+                Refer to the [original model card](https://huggingface.co/{source_model_id}) for more details on the model.
+                
+                ## Available Versions
+                {versions_text}
+                
+                ## Use with llama.cpp
+                Replace `FILENAME` with one of the above filenames.
+                
+                ### CLI:
+                ```bash
+                llama-cli --hf-repo {repo_id} --hf-file FILENAME -p "Your prompt here"
+                ```
+                
+                ### Server:
+                ```bash
+                llama-server --hf-repo {repo_id} --hf-file FILENAME -c 2048
+                ```
+                
+                ## Model Details
+                - **Original Model:** [{source_model_id}](https://huggingface.co/{source_model_id})
+                - **Format:** GGUF
+            """)
+            
+            # Save and upload README
+            readme_path = "/tmp/README.md"
+            card.save(readme_path)
+            api.upload_file(
+                path_or_fileobj=readme_path,
+                path_in_repo="README.md",
+                repo_id=repo_id
+            )
+            
+            # Upload all model files
+            for file_path, _ in model_files:
+                filename = os.path.basename(file_path)
+                logger.info(f"Uploading quantized model: {filename}")
+                api.upload_file(
+                    path_or_fileobj=file_path,
+                    path_in_repo=filename,
+                    repo_id=repo_id
+                )
+            
+            # Upload imatrix.dat if it exists
+            imatrix_path = "/root/llama.cpp/imatrix.dat"
+            if os.path.isfile(imatrix_path):
+                logger.info("Uploading imatrix.dat")
+                api.upload_file(
+                    path_or_fileobj=imatrix_path,
+                    path_in_repo="imatrix.dat",
+                    repo_id=repo_id
+                )
+                
+            logger.info("Upload completed successfully")
+            
+        except Exception as e:
+            logger.error(f"Error uploading to HuggingFace: {str(e)}")
+            raise
 
     @method()
     def push_to_ollama(


### PR DESCRIPTION
This pull request introduces a new method `upload_to_hf` in the `hugging_face_to_guff.py` file. This method facilitates the uploading of GGUF models to a HuggingFace repository, including the generation and uploading of a model card and README file, as well as handling multiple model files and additional data files.

Key changes include:

* Added `upload_to_hf` method for uploading GGUF models to HuggingFace, which includes:
  - Reloading the volume before upload.
  - Creating or updating a HuggingFace repository.
  - Generating a model card with tags and version details.
  - Uploading README and model files to the repository.
  - Handling optional upload of `imatrix.dat` if it exists.