### PR TITLE
Chore allow full cleanup of models

### DIFF
--- a/hugging_face_to_guff.py
+++ b/hugging_face_to_guff.py
@@ -91,6 +91,23 @@ class ModelConverter:
         import subprocess
 
         try:
+            # Clean model storage if clean_run is True
+            if clean_run:
+                logger.info("Clean run requested - cleaning model storage volume...")
+                models_dir = "/root/models"
+                if os.path.exists(models_dir):
+                    import shutil
+                    # Remove all contents of models directory
+                    for item in os.listdir(models_dir):
+                        item_path = os.path.join(models_dir, item)
+                        if os.path.isfile(item_path):
+                            os.unlink(item_path)
+                        elif os.path.isdir(item_path):
+                            shutil.rmtree(item_path)
+                    logger.info("Cleaned model storage directory")
+                    # Commit volume after cleanup
+                    volume.commit()
+
             local_dir = f"/root/models/{model_id.split('/')[-1]}-hf"
             os.makedirs(local_dir, exist_ok=True)
 


### PR DESCRIPTION
This pull request introduces a significant change to the `download_model` function in the `hugging_face_to_guff.py` file, adding a new feature to clean the model storage if a clean run is requested.

### New feature for cleaning model storage:

* Added a conditional block to check if `clean_run` is `True` and clean the model storage volume accordingly. This involves removing all contents of the models directory and committing the volume after cleanup.