### PR TITLE
Add mixtral model to the list of supported models in ollama_service.py

### DIFF
--- a/ollama_service.py
+++ b/ollama_service.py
@@ -26,7 +26,8 @@ MODEL_IDS: list[str] = [
     "Supa-AI/llama3-8b-cpt-sahabatai-v1-instruct:q8_0",
     "Supa-AI/gemma2-9b-cpt-sahabatai-v1-base:q8_0",
     "Supa-AI/ministral-8b-instruct-2410:q8_0",
-    "Supa-AI/mixtral-8x7b-instruct-v0.1:q8_0"
+    "Supa-AI/mixtral-8x7b-instruct-v0.1:q8_0",
+    "Supa-AI/malaysian-llama-3.2-3b-instruct:q8_0"
 ]
 
 OLLAMA_PORT: int = 11434

--- a/ollama_service.py
+++ b/ollama_service.py
@@ -22,11 +22,11 @@ MODEL_IDS: list[str] = [
     "qwen2.5",
     "yi",
     "aisingapore/gemma2-9b-cpt-sea-lionv3-instruct",
-    "hf.co/Supa-AI/malaysian-Llama-3.2-3B-Instruct-Q8_0-GGUF",
     "Supa-AI/gemma2-9b-cpt-sahabatai-v1-instruct:q8_0",
     "Supa-AI/llama3-8b-cpt-sahabatai-v1-instruct:q8_0",
     "Supa-AI/gemma2-9b-cpt-sahabatai-v1-base:q8_0",
-    "Supa-AI/ministral-8b-instruct-2410:q8_0"
+    "Supa-AI/ministral-8b-instruct-2410:q8_0",
+    "Supa-AI/mixtral-8x7b-instruct-v0.1:q8_0"
 ]
 
 OLLAMA_PORT: int = 11434


### PR DESCRIPTION
This pull request includes updates to the `ollama_service.py` file to modify the list of supported models. The most important changes involve removing outdated models and adding a new model to the list.

Updates to supported models:

* Removed `hf.co/Supa-AI/malaysian-Llama-3.2-3B-Instruct-Q8_0-GGUF` from the list of supported models.
* Added `Supa-AI/mixtral-8x7b-instruct-v0.1:q8_0` to the list of supported models.