### PR TITLE
Handle empty responses by providing a default message in ai_router

### DIFF
--- a/ai_router.py
+++ b/ai_router.py
@@ -212,10 +212,15 @@ async def handle_completion(
             )
 
         end_time = time.time()
-        
         response_obj.usage.response_time = (end_time - start_time) * 1000
         
-        response_obj.choices[0].message.content = redact_words(model_name, response_obj.choices[0].message.content)
+        # Check if response is empty and replace with default message
+        content = response_obj.choices[0].message.content
+        if not content or content.strip() == "":
+            response_obj.choices[0].message.content = "Sorry, I couldn't answer this question :("
+        else:
+            response_obj.choices[0].message.content = redact_words(model_name, content)
+            
         # Convert the usage object
         response_obj.usage = Usage.from_response(response_obj)
         


### PR DESCRIPTION
This pull request includes a change to the `ai_router.py` file to improve the handling of empty responses in the `handle_completion` function.

Improvements to response handling:

* [`ai_router.py`](diffhunk://#diff-7c35c14986a93d10e39f471b5296c405c044dc72e08ca213f6e5511160513e67L215-R223): Added a check to determine if the response content is empty and replace it with a default message "Sorry, I couldn't answer this question :(".