### PR TITLE
Increase idle timeout to 20 minutes

### DIFF
--- a/ollama_service.py
+++ b/ollama_service.py
@@ -266,7 +266,7 @@ async def proxy(request: Request, path: str):
         )
 
 @ollama_app.function(
-    gpu=gpu.A10G(count=2), allow_concurrent_inputs=10, concurrency_limit=1
+    gpu=gpu.A10G(count=2), allow_concurrent_inputs=10, concurrency_limit=1, container_idle_timeout=1200,
 )
 @modal.asgi_app()
 def ollama_api():


### PR DESCRIPTION
This pull request includes a change to the `ollama_service.py` file to improve the handling of idle containers in the `ollama_api` function.

* [`ollama_service.py`](diffhunk://#diff-eeee9573561f708202031c02b73ef2c83bd9c2c68eb9ea264e6ad12ab2046e38L269-R269): Added `container_idle_timeout=1200` to the `@ollama_app.function` decorator to specify a timeout of 1200 seconds for idle containers.