### PR TITLE
Develop increase idle timeout

### DIFF
--- a/ai_router.py
+++ b/ai_router.py
@@ -212,10 +212,15 @@ async def handle_completion(
             )
 
         end_time = time.time()
-        
         response_obj.usage.response_time = (end_time - start_time) * 1000
         
-        response_obj.choices[0].message.content = redact_words(model_name, response_obj.choices[0].message.content)
+        # Check if response is empty and replace with default message
+        content = response_obj.choices[0].message.content
+        if not content or content.strip() == "":
+            response_obj.choices[0].message.content = "Sorry, I couldn't answer this question :("
+        else:
+            response_obj.choices[0].message.content = redact_words(model_name, content)
+            
         # Convert the usage object
         response_obj.usage = Usage.from_response(response_obj)
         

--- a/ollama_service.py
+++ b/ollama_service.py
@@ -266,7 +266,7 @@ async def proxy(request: Request, path: str):
         )
 
 @ollama_app.function(
-    gpu=gpu.A10G(count=2), allow_concurrent_inputs=10, concurrency_limit=1
+    gpu=gpu.A10G(count=2), allow_concurrent_inputs=10, concurrency_limit=1, container_idle_timeout=1200,
 )
 @modal.asgi_app()
 def ollama_api():


### PR DESCRIPTION
This pull request includes a small change to the `ollama_service.py` file. The change adds a `container_idle_timeout` parameter to the `@ollama_app.function` decorator to specify a timeout duration for idle containers.

* [`ollama_service.py`](diffhunk://#diff-eeee9573561f708202031c02b73ef2c83bd9c2c68eb9ea264e6ad12ab2046e38L269-R269): Added `container_idle_timeout=1200` to the `@ollama_app.function` decorator in the `ollama_api` function.