### PR TITLE
update to two h100

### DIFF
--- a/ollama_service.py
+++ b/ollama_service.py
@@ -332,7 +332,7 @@ async def proxy(request: Request, path: str):
 
 
 @ollama_app.function(
-    gpu="L40S:2",
+    gpu="H100:2",
     allow_concurrent_inputs=10,
     max_containers=1,
     scaledown_window=1200,


### PR DESCRIPTION
This pull request includes a change to the `ollama_service.py` file to update the GPU configuration for the `_response` function.

* [`ollama_service.py`](diffhunk://#diff-eeee9573561f708202031c02b73ef2c83bd9c2c68eb9ea264e6ad12ab2046e38L335-R335): Changed the GPU configuration from `"L40S:2"` to `"H100:2"` in the `async def _response()` function.