### PR TITLE
Add snapshotting to ollama startup

### DIFF
--- a/ollama_service.py
+++ b/ollama_service.py
@@ -232,6 +232,7 @@ with ollama_app.image.imports():
         ),
     ],
     volumes={"/root/models": volume},
+    enable_memory_snapshot=True
 )
 class OllamaClient:
     _instance = None


### PR DESCRIPTION
This pull request includes a small but important change to the `update_model_db` function in the `ollama_service.py` file. The change enables memory snapshots by adding the `enable_memory_snapshot=True` parameter to the function call.

This will allow the ollama spin-up part when calling a model for the first time to be cached, significantly increasing performance on secondary model calls

Changes in `ollama_service.py`:

* [`def update_model_db()`](diffhunk://#diff-eeee9573561f708202031c02b73ef2c83bd9c2c68eb9ea264e6ad12ab2046e38R235): Enabled memory snapshots by adding the `enable_memory_snapshot=True` parameter.