### PR TITLE
Chore add rlhf site to cors

### DIFF
--- a/ai_router.py
+++ b/ai_router.py
@@ -26,6 +26,7 @@ web_app = FastAPI(
 origins = [
     "http://localhost:3000",
     "https://eval.supa.so",
+    "https://supa-rlhf.vercel.app/"
 ]
 
 # Add CORS middleware

--- a/ollama_service.py
+++ b/ollama_service.py
@@ -333,8 +333,8 @@ async def proxy(request: Request, path: str):
 
 
 @ollama_app.function(
-    gpu="H100:2",
-    allow_concurrent_inputs=10,
+    gpu="H100:1",
+    allow_concurrent_inputs=4,
     max_containers=1,
     scaledown_window=1200,
     enable_memory_snapshot=True,


### PR DESCRIPTION
This pull request includes updates to the `ai_router.py` and `ollama_service.py` files to improve the service's configuration and performance.

Configuration updates:

* [`ai_router.py`](diffhunk://#diff-7c35c14986a93d10e39f471b5296c405c044dc72e08ca213f6e5511160513e67R29): Added a new origin "https://supa-rlhf.vercel.app/" to the list of allowed origins for CORS.

Performance improvements:

* [`ollama_service.py`](diffhunk://#diff-eeee9573561f708202031c02b73ef2c83bd9c2c68eb9ea264e6ad12ab2046e38L336-R337): Adjusted the GPU allocation from "H100:2" to "H100:1" and reduced the `allow_concurrent_inputs` from 10 to 4 in the `_response` function to optimize resource usage.