### PR TITLE
Add rlhf + minor adjustments to main

### DIFF
--- a/ai_router.py
+++ b/ai_router.py
@@ -26,6 +26,7 @@ web_app = FastAPI(
 origins = [
     "http://localhost:3000",
     "https://eval.supa.so",
+    "https://supa-rlhf.vercel.app/"
 ]
 
 # Add CORS middleware

--- a/ollama_service.py
+++ b/ollama_service.py
@@ -333,8 +333,8 @@ async def proxy(request: Request, path: str):
 
 
 @ollama_app.function(
-    gpu="H100:2",
-    allow_concurrent_inputs=10,
+    gpu="H100:1",
+    allow_concurrent_inputs=4,
     max_containers=1,
     scaledown_window=1200,
     enable_memory_snapshot=True,

--- a/ollama_service.py
+++ b/ollama_service.py
@@ -332,7 +332,7 @@ async def proxy(request: Request, path: str):
 
 
 @ollama_app.function(
-    gpu="L40S:2",
+    gpu="H100:2",
     allow_concurrent_inputs=10,
     max_containers=1,
     scaledown_window=1200,

--- a/ollama_service.py
+++ b/ollama_service.py
@@ -232,6 +232,7 @@ with ollama_app.image.imports():
         ),
     ],
     volumes={"/root/models": volume},
+    enable_memory_snapshot=True
 )
 class OllamaClient:
     _instance = None


### PR DESCRIPTION
This pull request includes changes to update the CORS origins and modify the GPU and concurrency settings for the `ollama_service.py` file. The most important changes are:

CORS origins update:
* [`ai_router.py`](diffhunk://#diff-7c35c14986a93d10e39f471b5296c405c044dc72e08ca213f6e5511160513e67R29): Added a new origin `https://supa-rlhf.vercel.app/` to the list of allowed origins.

GPU and concurrency settings modification:
* [`ollama_service.py`](diffhunk://#diff-eeee9573561f708202031c02b73ef2c83bd9c2c68eb9ea264e6ad12ab2046e38L336-R337): Changed the GPU allocation from "H100:2" to "H100:1" and reduced the allowed concurrent inputs from 10 to 4 in the `_response` function.