### PR TITLE
Fix hallucinations

### DIFF
--- a/ai_router.py
+++ b/ai_router.py
@@ -26,7 +26,7 @@ web_app = FastAPI(
 origins = [
     "http://localhost:3000",
     "https://eval.supa.so",
-    "https://supa-rlhf.vercel.app/"
+    "https://supa-rlhf.vercel.app"
 ]
 
 # Add CORS middleware

--- a/ollama_service.py
+++ b/ollama_service.py
@@ -232,7 +232,6 @@ with ollama_app.image.imports():
         ),
     ],
     volumes={"/root/models": volume},
-    enable_memory_snapshot=True
 )
 class OllamaClient:
     _instance = None
@@ -337,7 +336,6 @@ async def proxy(request: Request, path: str):
     allow_concurrent_inputs=10,
     max_containers=1,
     scaledown_window=1200,
-    enable_memory_snapshot=True,
 )
 @modal.asgi_app()
 def ollama_api():

--- a/ollama_service.py
+++ b/ollama_service.py
@@ -28,7 +28,7 @@ MODEL_IDS: list[str] = [
     "llama3.2:3b-instruct-q8_0",
     "llama3.3:70b-instruct-q2_K",
     "llama3.3:70b-instruct-q6_K",
-    # "tinyllama:1.1b",
+    "tinyllama",
     "deepseek-coder-v2:16b",
     "deepseek-r1:1.5b",
     "mistral",
@@ -48,8 +48,8 @@ MODEL_IDS: list[str] = [
     "athene-v2:72b",
     # "deepseek-v3",
     "deepseek-r1",
-    # "deepseek-r1:70b",
-    "gemma3",
+    "deepseek-r1:70b",
+    # "gemma3",
     "phi4",
     "phi3:14b",
     "aisingapore/gemma2-9b-cpt-sea-lionv3-instruct",
@@ -61,6 +61,8 @@ MODEL_IDS: list[str] = [
     "hf.co/Supa-AI/malaysian-Llama-3.2-3B-Instruct-gguf:Q8_0",
     "command-a",
     "command-r7b-arabic",
+    "command-r",
+    "command-r-plus",
 ]
 
 OLLAMA_PORT: int = 11434
@@ -334,7 +336,6 @@ async def proxy(request: Request, path: str):
 @ollama_app.function(
     gpu="H100:1",
     allow_concurrent_inputs=4,
-    max_containers=1,
     scaledown_window=1200,
 )
 @modal.asgi_app()


### PR DESCRIPTION
This Pull request came about, as we were experiencing weird hallucinations with our R1 deepseek model, hosted on Ollama, where it would randomly start solving equations at a simple `hello` prompt.

I had redownloaded the model and it seems to be fixed now, I have also added some additional models and config changes

### Updates to origins:
* [`ai_router.py`](diffhunk://#diff-7c35c14986a93d10e39f471b5296c405c044dc72e08ca213f6e5511160513e67L29-R29): Corrected the URL for `https://supa-rlhf.vercel.app` by removing the trailing slash.

### Modifications to model lists:
* [`ollama_service.py`](diffhunk://#diff-eeee9573561f708202031c02b73ef2c83bd9c2c68eb9ea264e6ad12ab2046e38L31-R31): Added the model `tinyllama` and reordered the `deepseek-r1:70b` and `gemma3` models, uncommenting and commenting them respectively. [[1]](diffhunk://#diff-eeee9573561f708202031c02b73ef2c83bd9c2c68eb9ea264e6ad12ab2046e38L31-R31) [[2]](diffhunk://#diff-eeee9573561f708202031c02b73ef2c83bd9c2c68eb9ea264e6ad12ab2046e38L51-R52)
* [`ollama_service.py`](diffhunk://#diff-eeee9573561f708202031c02b73ef2c83bd9c2c68eb9ea264e6ad12ab2046e38R64-R65): Added `command-r` and `command-r-plus` to the list of models.

### Configuration adjustments:
* [`ollama_service.py`](diffhunk://#diff-eeee9573561f708202031c02b73ef2c83bd9c2c68eb9ea264e6ad12ab2046e38L235): Removed the `enable_memory_snapshot` parameter from the `update_model_db` function.
* [`ollama_service.py`](diffhunk://#diff-eeee9573561f708202031c02b73ef2c83bd9c2c68eb9ea264e6ad12ab2046e38L338-L340): Removed `max_containers` and `enable_memory_snapshot` parameters from the `_response` function.