### PR TITLE
Update to latest ollama image

### DIFF
--- a/ollama_service.py
+++ b/ollama_service.py
@@ -160,7 +160,7 @@ def update_model_db():
 
 image = (
     Image.from_registry(
-        "ollama/ollama:0.5.5",
+        "ollama/ollama:0.6.2",
         add_python="3.11",
     )
     .env(


### PR DESCRIPTION
This pull request includes an update to the `ollama_service.py` file to use a newer version of the `ollama` image. The change updates the image version from `0.5.5` to `0.6.2`.

* [`ollama_service.py`](diffhunk://#diff-eeee9573561f708202031c02b73ef2c83bd9c2c68eb9ea264e6ad12ab2046e38L163-R163): Updated the `ollama` image version from `0.5.5` to `0.6.2` in the `update_model_db` function.