### PR TITLE
Add huggingface_repo_id param to route_to_llm function

### DIFF
--- a/ai_router.py
+++ b/ai_router.py
@@ -536,6 +536,7 @@ async def route_model_request(
     anthropic_api_key: Optional[str] = None,
     output_struct: Optional[BaseModel] = None,
     huggingface_token: Optional[str] = None,
+    huggingface_repo_id: Optional[str] = None,
     huggingface_api_base: Optional[str] = None,
 
 ):


### PR DESCRIPTION
This pull request includes a small change to the `ai_router.py` file. The change adds an optional parameter to the `route_model_request` function to support specifying a Hugging Face repository ID.

* [`ai_router.py`](diffhunk://#diff-7c35c14986a93d10e39f471b5296c405c044dc72e08ca213f6e5511160513e67R539): Added `huggingface_repo_id` as an optional parameter to the `route_model_request` function.