### PR TITLE
Remove trailing slash from vercel app CORS origin URL

### DIFF
--- a/ai_router.py
+++ b/ai_router.py
@@ -26,7 +26,7 @@ web_app = FastAPI(
 origins = [
     "http://localhost:3000",
     "https://eval.supa.so",
-    "https://supa-rlhf.vercel.app/"
+    "https://supa-rlhf.vercel.app"
 ]
 
 # Add CORS middleware


### PR DESCRIPTION
This pull request includes a small change to the `ai_router.py` file. The change corrects the URL for the `supa-rlhf` origin by removing the trailing slash.