### PR TITLE
CORS error fix to main

### DIFF
--- a/ai_router.py
+++ b/ai_router.py
@@ -536,6 +536,7 @@ async def route_model_request(
     anthropic_api_key: Optional[str] = None,
     output_struct: Optional[BaseModel] = None,
     huggingface_token: Optional[str] = None,
+    huggingface_repo_id: Optional[str] = None,
     huggingface_api_base: Optional[str] = None,
 
 ):

--- a/ai_router.py
+++ b/ai_router.py
@@ -26,7 +26,7 @@ web_app = FastAPI(
 origins = [
     "http://localhost:3000",
     "https://eval.supa.so",
-    "https://supa-rlhf.vercel.app/"
+    "https://supa-rlhf.vercel.app"
 ]
 
 # Add CORS middleware


### PR DESCRIPTION
This pull request includes a small change to the `ai_router.py` file. The change removes the trailing slash from the URL in the `origins` list to ensure consistency and prevent potential issues with URL matching.

* [`ai_router.py`](diffhunk://#diff-7c35c14986a93d10e39f471b5296c405c044dc72e08ca213f6e5511160513e67L29-R29): Removed the trailing slash from the URL `https://supa-rlhf.vercel.app/` in the `origins` list.